### PR TITLE
[cloud] Added git support to fabric

### DIFF
--- a/cloud/fabfile.py
+++ b/cloud/fabfile.py
@@ -47,7 +47,7 @@ def proxy():
     env.use_ssh_config = True
 
 def is_hg():
-    #first test for hg
+    """ Determines if the project is hg controlled """
     try:
         local("hg identify")
         return True
@@ -55,7 +55,7 @@ def is_hg():
         return False
 
 def is_git():
-    #first test for hg
+    """ Determines if the project is git controlled """
     try:
         local("git rev-parse")
         return True

--- a/cloud/fabfile.py
+++ b/cloud/fabfile.py
@@ -245,7 +245,7 @@ def get_machines(environment=None):
 
 def deploy(description=None):
     """ [deploy] Make a deployment to an environment. """
-    branch = get_bookmark()
+    branch, summary, version = _get_versioning_metadata()
     try:
         if env.deploy_target == "production":
             if branch != "master":
@@ -300,7 +300,7 @@ def migrate(application="", migration="", fake_initial=""):
     Usage:
       fab staging migrate:application=endagaweb,fake_initial=True
     """
-    branch = get_bookmark()
+    branch, summary, version = _get_versioning_metadata()
     try:
         if env.deploy_target == "production":
             if branch != "master":

--- a/cloud/fabfile.py
+++ b/cloud/fabfile.py
@@ -46,7 +46,8 @@ def proxy():
     env.ssh_config_path = "../client/ssh/proxy-config"
     env.use_ssh_config = True
 
-def is_hg():
+
+def _is_hg():
     """ Determines if the project is hg controlled """
     try:
         local("hg identify")
@@ -54,7 +55,8 @@ def is_hg():
     except:
         return False
 
-def is_git():
+
+def _is_git():
     """ Determines if the project is git controlled """
     try:
         local("git rev-parse")
@@ -62,10 +64,11 @@ def is_git():
     except:
         return False
 
+
 def get_bookmark():
-    if (is_hg()):
+    if (_is_hg()):
         bookmarks = local("hg bookmarks", capture=True)
-    elif(is_git()):
+    elif(_is_git()):
         bookmarks = local("git branch", capture=True)
     else:
         raise(Exception("Not git or hg"))
@@ -77,9 +80,9 @@ def get_bookmark():
 def package():
     """ [deploy] Creates a deployment package. """
     branch = get_bookmark()
-    if (is_hg()):
+    if (_is_hg()):
         commit_summary = local('hg id -i', capture=True).translate(None, "+")
-    elif(is_git()):
+    elif(_is_git()):
         commit_summary = local('git rev-parse HEAD', capture=True).translate(None, "+")
     else:
         raise(Exception("Not git or hg"))

--- a/cloud/fabfile.py
+++ b/cloud/fabfile.py
@@ -68,21 +68,23 @@ def _is_git():
 def _get_versioning_metadata():
     """ Extracts version metadata from the version control system """
     if (_is_hg()):
-        bookmarks = local("hg bookmarks", capture=True)
         commit_summary = local('hg id -i', capture=True).translate(None, "+")
+        # Extract the current branch/bookmark from the bookmarks list.
+        bookmarks = local("hg bookmarks", capture=True)
+        branch = "master"
+        for line in bookmarks.split("\n"):
+            if "*" in line:
+                 branch = line.split()[1]
+                 break
     elif(_is_git()):
-        bookmarks = local("git branch", capture=True)
+        branch = local("git rev-parse --abbrev-ref HEAD", capture=True)
         commit_summary = local('git rev-parse HEAD', capture=True).translate(None, "+")
     else:
         raise(Exception("Not git or hg"))
 
     # dpkg requires the version start with a number, so lead with `0-`
     version = "0-%s" % commit_summary.split()[0]
-
-    for line in bookmarks.split("\n"):
-        if "*" in line:
-            return line.split()[1], commit_summary, version
-    return "master", commit_summary, version
+    return branch, commit_summary, version
 
 
 def package():


### PR DESCRIPTION
Summary: Allow fabric to fall back to git if a mercurial repo is not found or mercurial is not installed. This is needed for a real deployment of the git based public projected. As with the previous pull request, please let us know what the standards are for community pull requests if there is anything we should update or change!
Cheers,
-mj