### PR TITLE
Subscriber balance zero out when validity expire (Client dependent)

### DIFF
--- a/cloud/endagaweb/celery.py
+++ b/cloud/endagaweb/celery.py
@@ -42,5 +42,9 @@ app.conf.update(CELERYBEAT_SCHEDULE={
         'task': 'endagaweb.tasks.usageevents_to_sftp',
         # Run this at 15:00 UTC (10:00 PDT, 02:00 Papua time)
         'schedule': crontab(minute=0, hour=17),
-    }
+    }, 'zero_out_subscribers_balance': {
+        'task': 'endagaweb.tasks.zero_out_subscribers_balance',
+        # Run this at 12:00 UTC (07:00 PDT, 12:00 Papua time).
+        'schedule': crontab(minute='0', hour=07),
+    },
 })

--- a/cloud/endagaweb/tasks.py
+++ b/cloud/endagaweb/tasks.py
@@ -43,7 +43,7 @@ from endagaweb.models import UsageEvent
 from endagaweb.models import SystemEvent
 from endagaweb.models import TimeseriesStat
 from endagaweb.ic_providers.nexmo import NexmoProvider
-
+from ccm.common import crdt
 
 @app.task(bind=True)
 def usageevents_to_sftp(self):
@@ -439,3 +439,20 @@ def req_bts_log(self, obj, retry_delay=60*10, max_retries=432):
         raise
     finally:
       obj.save()
+
+
+@app.task(bind=True)
+def zero_out_subscribers_balance(self):
+    """Subscriber balance zero outs when validity expires.
+
+    This runs this as a periodic task managed by celerybeat.
+    """
+    today = django.utils.timezone.now()
+    subscribers = Subscriber.objects.filter(
+        valid_through__lte=today)
+    if not subscribers:
+        return  # Do nothing
+    credit_balance = crdt.PNCounter("default").serialize()
+    print "Validity expired for Susbcribers %s setting balance to 0" % (
+        [subscriber.imsi for subscriber in subscribers],)
+    subscribers.update(crdt_balance=credit_balance)


### PR DESCRIPTION
Please review subscriber balance zero out feature:
- On the expiry of validity, available balance should be zero out
- Validity will be assigned from PR# https://github.com/facebookincubator/CommunityCellularManager/pull/40

This PR is linked with #40 