### PR TITLE
Update postgres.dev.yml, replace sudo/sudo_user with become/become_user

### DIFF
--- a/cloud/ansible/postgres.dev.yml
+++ b/cloud/ansible/postgres.dev.yml
@@ -7,7 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 - hosts: db
-  sudo: yes
+  become: true
   vars:
     db_name: endagaweb_dev
     db_user: endaga_dev
@@ -39,19 +39,19 @@
           - python-psycopg2
 
     - name: Add Endaga DB
-      sudo_user: postgres
+      become_user: postgres
       postgresql_db: name={{ db_name }} state=present
 
     - name: Add Endaga DB user
-      sudo_user: postgres
+      become_user: postgres
       postgresql_user: db={{ db_name }} name={{ db_user }} password={{ db_password }} priv=ALL role_attr_flags=CREATEDB
 
     - name: Add postgis support
-      sudo_user: postgres
+      become_user: postgres
       postgresql_ext: name=postgis db={{ db_name }}
 
     - name: Enable postgres support
-      sudo_user: postgres
+      become_user: postgres
       shell: psql -d template1 -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
     - name: Listen for remote connections


### PR DESCRIPTION
I encountered this error when setting the cloud VMs up on a new computer. 

```
TASK [Add Endaga DB] ***********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OperationalError: FATAL:  Peer authentication failed for user "postgres"
fatal: [db]: FAILED! => {"changed": false, "msg": "unable to connect to database: FATAL:  Peer authentication failed for user \"postgres\"\n"}
	to retry, use: --limit @/home/sago/Documents/PCARI/DEV3/CCM_20171212/CommunityCellularManager/cloud/ansible/postgres.dev.retry

PLAY RECAP *********************************************************************
db                         : ok=2    changed=1    unreachable=0    failed=1   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Replacing sudo/sudo_user with become/become_user fixed this and the DB vm was completed without any hiccups. 
This is also partially mentioned in #20 