### PR TITLE
Ignore generated python artifacts

### DIFF
--- a/osmocom-python/.gitignore
+++ b/osmocom-python/.gitignore
@@ -1,0 +1,4 @@
+### python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/smspdu/.gitignore
+++ b/smspdu/.gitignore
@@ -1,0 +1,4 @@
+### python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
This pull request adds basic .gitignore files for python artifacts generated by the test code in the smspdu and osmocom-python directories.