### PR TITLE
[osmocom-python] Fix broken test include path

### DIFF
--- a/osmocom-python/tests/gsup/processor_tests.py
+++ b/osmocom-python/tests/gsup/processor_tests.py
@@ -11,11 +11,11 @@ import unittest
 
 from unittest.mock import Mock
 
-from osmocom.util import SIDUtils
 from osmocom.gsup.crypto.utils import CryptoError
 from osmocom.gsup import processor
 from osmocom.gsup.store.base import SubscriberNotFoundError
 from osmocom.gsup.store.sqlite import SqliteStore
+from osmocom.gsup.store.util import SIDUtils
 from osmocom.gsup.store.protos.subscriber_pb2 import (GSMSubscription,
                                      SubscriberData, SubscriberState)
 


### PR DESCRIPTION
util.py appears to have been moved from osmocom to osmocom.gsup.store
without a corresponding update to the test.